### PR TITLE
writekey is managed as credential data, so it is neither visible nor exportable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-thingspeak",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "description": "A simple node for node-red which allow to send data to thingspeak",
   "dependencies": {},
   "keywords": ["node-red"],

--- a/thingspeak/thingspeak.html
+++ b/thingspeak/thingspeak.html
@@ -4,8 +4,10 @@
         color: '#a6bbcf',
         defaults: {
             name: {value:""},
-            writekey: {value:""},
             fieldid: {value:""}
+        },
+        credentials: {
+            writekey: {type:"password", required:true}
         },
         inputs:1,
         outputs:0,
@@ -23,7 +25,7 @@
     </div>
     <div class="form-row">
         <label for="node-input-writekey"><i class="icon-tag"></i> Write Key</label>
-        <input type="text" id="node-input-writekey" placeholder="ABCDEF1234567">
+        <input type="password" id="node-input-writekey" placeholder="ABCDEF1234567">
     </div>
     <div class="form-row">
         <label for="node-input-fieldid"><i class="icon-tag"></i> Field ID</label>

--- a/thingspeak/thingspeak.js
+++ b/thingspeak/thingspeak.js
@@ -6,7 +6,7 @@ module.exports = function(RED) {
     var node = this;
     this.on('input', function(msg) {
       https.get(
-        "https://api.thingspeak.com/update?api_key="+config.writekey+"&field"+config.fieldid+"="+msg.payload,
+        "https://api.thingspeak.com/update?api_key="+this.credentials.writekey+"&field"+config.fieldid+"="+msg.payload,
         function(response) {
           if(response.statusCode == 200){
             node.log("OK");
@@ -17,5 +17,5 @@ module.exports = function(RED) {
       );
     });
   }
-  RED.nodes.registerType("ThingspeakSendSimple", ThingspeakSendSimple);
+  RED.nodes.registerType("ThingspeakSendSimple", ThingspeakSendSimple, {credentials: {writekey:{type:"password",required:true}}});
 }


### PR DESCRIPTION
Just configured 'writekey' as credential type. In this way, the key is safe. A simple change that makes to node useful when you are only interested in publishing to one field